### PR TITLE
fix: react native ssl and git repo in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ fs.writeFileSync(`${document.title}.pdf`, file);
 // Get a documents thumbnail
 await paperless.getThumbnail(2);
 ```
+
+## React Native
+
+This package is compatible with React Native. However, the `ignoreSSL` feature is not supported and will throw errors, if you set this to true. 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A paperless-ng api client",
   "main": "dist/index.js",
   "author": "Tom <me@dunklesToast.de>",
+  "repository": "https://github.com/openlabapps/paperless-api",
   "license": "MIT",
   "private": false,
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,5 @@
 import type { AxiosInstance } from 'axios';
 import axios from 'axios';
-import * as fs from 'fs';
-import * as https from 'https';
 import type { Config } from './types/Config';
 import type { CorrespondentResponse } from './types/Correspondents';
 import type { DocumentTypeResponse } from './types/DocumentTypes';
@@ -14,10 +12,7 @@ export class Paperless {
 
   constructor(config: Config) {
     const baseURL = config.port ? `${config.host}:${config.port}` : config.host;
-    this.instance = axios.create({
-      httpsAgent: new https.Agent({
-        rejectUnauthorized: !config.ignoreSSL,
-      }),
+    const options: Record<string, any> = {
       baseURL: `${baseURL}/api`,
       headers: {
         Accept: 'application/json; version=2',
@@ -26,7 +21,17 @@ export class Paperless {
         username: config.username,
         password: config.password,
       },
-    });
+    };
+
+    if (config.ignoreSSL) {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires,global-require
+      const https = require('https');
+      options.httpsAgent = new https.Agent({
+        rejectUnauthorized: !config.ignoreSSL,
+      });
+    }
+
+    this.instance = axios.create(options);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export class Paperless {
 
   constructor(config: Config) {
     const baseURL = config.port ? `${config.host}:${config.port}` : config.host;
-    const options: Record<string, any> = {
+    const options: Record<string, unknown> = {
       baseURL: `${baseURL}/api`,
       headers: {
         Accept: 'application/json; version=2',
@@ -92,7 +92,7 @@ export class Paperless {
    */
   public async search(query: string): Promise<Metadata>;
 
-  public async search(query: string | DocumentId): Promise<any> {
+  public async search(query: string | DocumentId): Promise<Metadata> {
     let searchParams: Record<string, string | DocumentId> = {};
 
     if (typeof query === 'number') {

--- a/src/types/Document.ts
+++ b/src/types/Document.ts
@@ -20,7 +20,7 @@ export type Document = {
   /** ISO-8601 formatted added date */
   added: string;
   /** UNKNOWN */
-  archive_serial_number: any;
+  archive_serial_number: unknown;
   /** Filename before Import */
   original_file_name: string;
   /** Filename after archiving */

--- a/src/types/Search.ts
+++ b/src/types/Search.ts
@@ -31,7 +31,7 @@ export type SearchResult = {
   /** ISO-8601 formatted added date */
   added: string;
   /** UNKNOWN */
-  archive_serial_number: any;
+  archive_serial_number: unknown;
   /** Filename before Import */
   original_file_name: string;
   /** Filename after archiving */


### PR DESCRIPTION
This should fix a Bug in React Native where the `import` was `undefined` because it failed loading the `https` module. `ignoreSSL` is therefore not supported in React Native, you could probably polyfill it.
Additionally, I added the Repository to the package.json so npm will show it.