### PR TITLE
fix: exclude https package from react-native bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .idea
 *.log
+dist

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
+  },
+  "react-native": {
+    "https": false
   }
 }


### PR DESCRIPTION
As seen [here](https://stackoverflow.com/a/43066705/5343568).
Also, added `dist` to `.gitignore`.